### PR TITLE
Make react-fixed-page compatible with React 15.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "react-side-effect": "^1.1.0",
     "webpack": "^1.12.14"
   },
+  "dependencies": {
+    "prop-types": "^15.5.8"
+  },
   "peerDependencies": {
     "react": "^15.3.0"
   }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,5 +1,6 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import withSideEffect from 'react-side-effect';
+import PropTypes from 'prop-types';
 
 class FixedPage extends Component {
   static propTypes = {


### PR DESCRIPTION
This should prevent deprecation warnings introduced in React 15.5.0

#1 